### PR TITLE
feat: ranks with only 1 layer auto-exit and rebuild topology

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1731,6 +1731,14 @@ struct llama_init_result llama_init_from_gpt_params(gpt_params & params) {
             n_gpu_layers[i] = n_gpu_layers_temp[i];
         }
         llama_update_context_with_rankworld(lctx, update_rank, update_n_world);
+        cparams.rank = update_rank;
+        cparams.n_world = update_n_world;
+        mparams.rank = update_rank;
+        mparams.n_world = update_n_world;
+        params.rank = update_rank;
+        params.n_world = update_n_world;
+        my_rank = update_rank;
+        n_world = update_n_world;
 
         // update n_layer_window and n_gpu_layers
         std::copy(std::begin(n_layer_window), std::end(n_layer_window), params.n_layer_window);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1547,7 +1547,7 @@ static bool tune_layer_allocation(
         dev_infos_temp.clear();
         n_layer_windows_temp.clear();
         n_gpu_layers_temp.clear();
-        for(auto i=0; i<n_world; i++) {
+        for(uint32_t i=0; i<n_world; i++) {
             if (n_layer_windows_[i] > 1 || i==0 ) {
                 dev_infos_temp.push_back(dev_infos_[i]);
                 n_layer_windows_temp.push_back(n_layer_windows_[i]);
@@ -1561,7 +1561,7 @@ static bool tune_layer_allocation(
 
         n_world = dev_infos_temp.size();
     }
-    int i =0 , j =0;
+    uint32_t i =0 , j =0;
     while(j < n_world) {
         if(dev_infos[i].rank == dev_infos_temp[j].rank){
             n_layer_window[i] = n_layer_windows_temp[j];
@@ -1701,13 +1701,19 @@ struct llama_init_result llama_init_from_gpt_params(gpt_params & params) {
                 llama_recv_layer_setup(lctx, n_layer_window, n_gpu_layers);
             }
         }
+        if(n_layer_window[my_rank]<=0){
+            LOG_INF("%s: info: rank %d has no layers to run, skipping\n", __func__, my_rank);
+            llama_free(lctx);
+            llama_free_model(model);
+            exit(0);
+        }
 
         //update rank and n_world for consistency
         uint32_t update_rank = 0;
         uint32_t update_n_world = 1;
         std::vector<uint32_t> n_layer_window_temp = {n_layer_window[0]};
         std::vector<uint32_t> n_gpu_layers_temp = {n_gpu_layers[0]};
-        for(auto i=1; i<n_world; i++) {
+        for(uint32_t i=1; i<n_world; i++) {
             if(n_layer_window[i] <= 0 ){
                 continue;
             }
@@ -1720,7 +1726,7 @@ struct llama_init_result llama_init_from_gpt_params(gpt_params & params) {
         }
         memset(n_layer_window, 0, n_world * sizeof(uint32_t));
         memset(n_gpu_layers, 0, n_world * sizeof(uint32_t));
-        for (auto i=0; i<update_n_world; i++) {
+        for (uint32_t i=0; i<update_n_world; i++) {
             n_layer_window[i] = n_layer_window_temp[i];
             n_gpu_layers[i] = n_gpu_layers_temp[i];
         }

--- a/common/profiler.cpp
+++ b/common/profiler.cpp
@@ -2358,15 +2358,17 @@ size_t serialize(const struct device_info * dev_info, char ** buffer) {
     // calculate total size for serialized buffer
     size_t device_name_len     = strlen(dev_info->device_name) + 1;
     size_t device_os_len       = strlen(dev_info->device_os) + 1;
+    size_t next_ip_len         = strlen(dev_info->next_ip) + 1;
     size_t cpu_name_len        = strlen(dev_info->cpu_props.name) + 1;
     size_t cpu_description_len = strlen(dev_info->cpu_props.description) + 1;
     size_t gpu_name_len        = strlen(dev_info->gpu_props.name) + 1;
     size_t gpu_description_len = strlen(dev_info->gpu_props.description) + 1;
 
     size_t total_size = sizeof(uint32_t)
-                      + sizeof(size_t) * 6  // for lengths of strings
+                      + sizeof(size_t) * 7  // for lengths of strings
                       + device_name_len
                       + device_os_len
+                      + next_ip_len
                       + cpu_name_len
                       + cpu_description_len
                       + gpu_name_len
@@ -2425,6 +2427,11 @@ size_t serialize(const struct device_info * dev_info, char ** buffer) {
     ptr += sizeof(size_t);
     memcpy(ptr, dev_info->device_os, device_os_len);
     ptr += device_os_len;
+
+    memcpy(ptr, &next_ip_len, sizeof(size_t));
+    ptr += sizeof(size_t);
+    memcpy(ptr, dev_info->next_ip, next_ip_len);
+    ptr += next_ip_len;
 
     memcpy(ptr, &cpu_name_len, sizeof(size_t));
     ptr += sizeof(size_t);
@@ -2610,6 +2617,14 @@ void deserialize(const char * buffer, struct device_info * dev_info) {
     dev_info->device_os = (char *)malloc(device_os_len);
     memcpy(const_cast<void*>(static_cast<const void*>(dev_info->device_os)), ptr, device_os_len);
     ptr += device_os_len;
+
+    // next ip
+    size_t next_ip_len;
+    memcpy(&next_ip_len, ptr, sizeof(size_t));
+    ptr += sizeof(size_t);
+    dev_info->next_ip = (char *)malloc(next_ip_len);
+    memcpy(const_cast<void*>(static_cast<const void*>(dev_info->next_ip)), ptr, next_ip_len);
+    ptr += next_ip_len;
 
     // cpu_props.name
     size_t cpu_name_len;

--- a/common/profiler.h
+++ b/common/profiler.h
@@ -320,6 +320,7 @@ struct device_info {
     uint32_t            rank;
     const char *        device_name;
     const char *        device_os;
+    const char *        next_ip;
     struct disk_props   disk;
     struct cpu_props    cpu_props;
     struct memory_info  memory;
@@ -333,6 +334,7 @@ struct device_info {
         rank(0), 
         device_name(""), 
         device_os(""),
+        next_ip(""),
         disk(),
         cpu_props(), 
         memory(), 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -143,8 +143,8 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    const uint32_t n_world  = params.n_world;
-    const uint32_t my_rank  = params.rank;
+    uint32_t n_world  = params.n_world;
+    uint32_t my_rank  = params.rank;
     GGML_ASSERT(!(n_world == 1 && my_rank > 0));
 
     // check if --n-layer-window and --world is matched
@@ -200,6 +200,9 @@ int main(int argc, char ** argv) {
     // load the model and apply lora adapter, if any
     LOG_INF("%s: load the model and apply lora adapter, if any\n", __func__);
     llama_init_result llama_init = llama_init_from_gpt_params(params);
+    // update
+    my_rank = params.rank;
+    n_world = params.n_world;
 
     model = llama_init.model;
     ctx = llama_init.context;

--- a/include/llama.h
+++ b/include/llama.h
@@ -462,7 +462,11 @@ extern "C" {
               struct llama_model_loader * ml,
               struct llama_model        * model,
               struct llama_model_params   params);
-
+    
+    LLAMA_API void llama_update_context_with_rankworld(struct llama_context * ctx,
+                                                                     uint32_t rank,
+                                                                     uint32_t n_world);
+    
     LLAMA_API struct llama_context * llama_new_context_with_model(
                      struct llama_model * model,
             struct llama_context_params   params);

--- a/include/llama.h
+++ b/include/llama.h
@@ -455,6 +455,7 @@ extern "C" {
     LLAMA_API int  llama_send_device_info  (struct llama_context * ctx, struct device_info * dev_info);
     LLAMA_API int  llama_bcast_startup_args(struct llama_context * ctx, uint32_t rank,  struct startup_args * args);
     LLAMA_API int  llama_bcast_layer_setup (struct llama_context * ctx, uint32_t * n_layer_window, uint32_t * n_gpu_layers);
+    LLAMA_API int  llama_rebuild_topo      (struct llama_context * ctx, uint32_t * n_layer_window, struct device_info * dev_info_set);
     LLAMA_API int  llama_recv_layer_setup  (struct llama_context * ctx, uint32_t * n_layer_window, uint32_t * n_gpu_layers);
 
     LLAMA_API int llm_load_tensors(

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -20475,6 +20475,15 @@ void llama_free_sockets(struct llama_context * ctx, char ** msg) {
     }
 }
 
+void llama_update_context_with_rankworld(struct llama_context * ctx,
+                                                       uint32_t rank,
+                                                       uint32_t n_world) {
+    if(ctx) {
+        ctx->cparams.rank = rank;
+        ctx->cparams.n_world = n_world;
+    }
+}
+
 struct llama_context * llama_new_context_with_model(
                  struct llama_model * model,
         struct llama_context_params   params) {


### PR DESCRIPTION
Under the automatic allocation mode(`-lw` not specified), all ranks join and layers are allocated within `rank0`. 
This PR adds:
- `Rank0` will automatically remove ranks assigned with "1 layer" (except rank0 itself) and repeatedly run the layer allocation algorithm until only ranks without "1 layer" remain. 
- Nodes marked for exit are assigned layer 0. 
- `Rank0` start a ring topology reconstruction operation.
### Topology Reconstruction
- Added `next_ip` field to `device_info`
- `Rank0` broadcasts all nodes' `device_info` and `n_layer_window`
- `Ranks` assigned "layer 0" will automatically exit
- Remaining nodes will automatically establish new socket connections with their next node in the ring
### Metadata Update
Since the entire system heavily relies on two metadata fields—`rank` and `n_world`—as well as the continuity of rank arrangement (e.g. `next_rank = (my_rank + 1) % n_world`), after the topology reconstruction process completes, the `rank` values of remaining nodes will be reassigned sequentially.
For example:
- Original `ranks`: 0 1 2 3
- Original `n_world`: 4
- Layer assignments: 1 2 0 2 
Updated ranks will be: `0 1 x 2`, and `n_world` will be updated to 3
### Note:
`Rank0` will never exit, regardless of whether it is assigned "1 layer," and its rank will always remain 0.

### Tests
1. Case 1
- node number: 3
- original layer assignments: 1 1 26
![PixPin_2025-05-16_18-35-10](https://github.com/user-attachments/assets/7fc98a9a-67f9-4f7e-9da4-fd1de32ec177)

rank1 exits and layer assignments become: `1 27`
![PixPin_2025-05-16_18-35-28](https://github.com/user-attachments/assets/4cfac611-8faa-44b8-b613-4a6327b44ed1)

2. Case 2
- node number: 3
- original layer assignments: 1 26 1
![PixPin_2025-05-16_20-56-31](https://github.com/user-attachments/assets/0960ae01-9fe3-4e45-9a28-e0bef61880df)

rank1 exits and layer assignments become: `1 27`
![PixPin_2025-05-16_20-56-42](https://github.com/user-attachments/assets/98cb2b7a-ca23-4f6e-85e1-ebf3a77b1aea)

3. Case 3
- node number: 3
- original layer assignments: 26 1 1
![PixPin_2025-05-16_21-25-19](https://github.com/user-attachments/assets/5c39d5ab-e41a-4aa7-8788-a0fe520d0a1d)

rank1 and rank2 exit
![PixPin_2025-05-16_21-25-45](https://github.com/user-attachments/assets/97ef8fbe-11c1-4bd9-afb1-2fabdf15ff29)

### Results

Remaining nodes' inferrence is good.
![PixPin_2025-05-16_20-51-45](https://github.com/user-attachments/assets/ea773f03-d249-4905-8612-ff87d3ab533e)



