### PR TITLE
feat: nodes attempt connections during topology rebuild while preserving critical forwarders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -950,7 +950,8 @@ OBJ_LLAMA = \
 	src/llama-grammar.o \
 	src/llama-sampling.o \
 	src/unicode.o \
-	src/unicode-data.o
+	src/unicode-data.o \
+	src/network-utils.o \
 
 OBJ_COMMON = \
 	common/profiler.o \
@@ -1139,6 +1140,11 @@ src/unicode-data.o: \
 	src/unicode-data.cpp \
 	src/unicode-data.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
+	
+src/network-utils.o: \
+	src/network-utils.cpp \
+	src/network-utils.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 src/llama.o: \
 	src/llama.cpp \
@@ -1147,6 +1153,7 @@ src/llama.o: \
 	src/llama-grammar.h \
 	src/llama-sampling.h \
 	src/unicode.h \
+	src/network-utils.h \
 	include/llama.h \
 	ggml/include/ggml-cuda.h \
 	ggml/include/ggml-metal.h \

--- a/common/profiler.cpp
+++ b/common/profiler.cpp
@@ -2621,7 +2621,7 @@ size_t serialize(const struct device_info * dev_info, char ** buffer) {
     return total_size;
 }
 
-void deserialize(const char * buffer, struct device_info * dev_info) {
+size_t deserialize(const char * buffer, struct device_info * dev_info) {
     const char * ptr = buffer;
 
     // rank
@@ -2821,6 +2821,32 @@ void deserialize(const char * buffer, struct device_info * dev_info) {
     ptr += sizeof(float);
 
     memcpy(&dev_info->gpu_props.cuda_mem_cpy_delay, ptr, sizeof(float));
+    ptr += sizeof(float);
 
     // no need to synchronize model flops and model params
+    return ptr - buffer;
+}
+
+void TopoRebuildHelperInfo::deserialize(const char *buffer) {
+    size_t buffer_size = ::deserialize(buffer, &dev_info);
+    if (buffer_size == 0) {
+        LOG_ERR("%s: failed to deserialize device info\n", __func__);
+        return;
+    }
+    memcpy(&is_fowarder, buffer + buffer_size, 1);
+}
+
+size_t TopoRebuildHelperInfo::serialize(char **buffer) const{ 
+    size_t buffer_size = ::serialize(&dev_info, buffer);
+    char* buffer_ = (char*)malloc(buffer_size+1);
+    if (buffer_ == NULL) {
+        LOG_ERR("%s: failed to allocate %zu bytes for device info serialization\n", 
+                __func__, buffer_size);
+        return 0;
+    }
+    memcpy(buffer_, *buffer, buffer_size);
+    memcpy(buffer_ + buffer_size, &is_fowarder, 1);
+    free(*buffer);
+    *buffer = buffer_;
+    return buffer_size + 1;
 }

--- a/common/profiler.cpp
+++ b/common/profiler.cpp
@@ -2833,7 +2833,7 @@ void TopoRebuildHelperInfo::deserialize(const char *buffer) {
         LOG_ERR("%s: failed to deserialize device info\n", __func__);
         return;
     }
-    memcpy(&is_fowarder, buffer + buffer_size, 1);
+    memcpy(&is_forwarder, buffer + buffer_size, 1);
 }
 
 size_t TopoRebuildHelperInfo::serialize(char **buffer) const{ 
@@ -2845,7 +2845,7 @@ size_t TopoRebuildHelperInfo::serialize(char **buffer) const{
         return 0;
     }
     memcpy(buffer_, *buffer, buffer_size);
-    memcpy(buffer_ + buffer_size, &is_fowarder, 1);
+    memcpy(buffer_ + buffer_size, &is_forwarder, 1);
     free(*buffer);
     *buffer = buffer_;
     return buffer_size + 1;

--- a/common/profiler.h
+++ b/common/profiler.h
@@ -346,6 +346,18 @@ struct device_info {
         model_bytes() {}
 };
 
+struct TopoRebuildHelperInfo{
+    struct device_info dev_info;
+    char               is_fowarder;
+    
+    TopoRebuildHelperInfo():
+        dev_info(),
+        is_fowarder(0){}
+    
+    void   deserialize(const char * buffer);
+    size_t serialize(char ** buffer) const;
+};
+
 enum profiler_backend_type {
     PROFILER_BACKEND_TYPE_CPU   = 0,
     PROFILER_BACKEND_TYPE_METAL = 1,
@@ -389,6 +401,6 @@ int      device_has_blas   (void);
 int      device_has_sycl   (void);
 
 size_t   serialize  (const struct device_info * dev_info, char ** buffer);
-void     deserialize(const char * buffer, struct device_info * dev_info);
+size_t   deserialize(const char * buffer, struct device_info * dev_info);
 
 #endif // PROFILER_H

--- a/common/profiler.h
+++ b/common/profiler.h
@@ -348,11 +348,11 @@ struct device_info {
 
 struct TopoRebuildHelperInfo{
     struct device_info dev_info;
-    char               is_fowarder;
+    char               is_forwarder;
     
     TopoRebuildHelperInfo():
         dev_info(),
-        is_fowarder(0){}
+        is_forwarder(0){}
     
     void   deserialize(const char * buffer);
     size_t serialize(char ** buffer) const;

--- a/include/llama.h
+++ b/include/llama.h
@@ -477,7 +477,9 @@ extern "C" {
     LLAMA_API void llama_update_context_with_rankworld(
                    struct llama_context * ctx, 
                                uint32_t   rank, 
-                               uint32_t   n_world);
+                               uint32_t   n_world,
+                               uint32_t   worker_rank,
+                               uint32_t   n_worker);
     
     LLAMA_API struct llama_context * llama_new_context_with_model(
                      struct llama_model * model,

--- a/include/llama.h
+++ b/include/llama.h
@@ -451,7 +451,7 @@ extern "C" {
     
     enum NodeType{
         NODE_TYPE_WORKER,
-        NODE_TYPE_FOWARDER,
+        NODE_TYPE_FORWARDER,
         NODE_TYPE_EXIT,
     };
 
@@ -463,10 +463,10 @@ extern "C" {
     LLAMA_API int  llama_bcast_layer_setup (struct llama_context * ctx, uint32_t * n_layer_window, uint32_t * n_gpu_layers);
     LLAMA_API int  llama_rebuild_topo      (struct llama_context * ctx, 
                                                         uint32_t * n_layer_window, 
-                                              struct device_info * dev_info_set, 
+                                              struct device_info * desv_info_set, 
                                                          NodeType* node_type,
-                                                         char    * is_fowarder);
-    LLAMA_API int  llama_foward_messages   (struct llama_context * ctx);
+                                                         char    * is_forwarder);
+    LLAMA_API int  llama_forward_messages   (struct llama_context * ctx);
     LLAMA_API int  llama_recv_layer_setup  (struct llama_context * ctx, uint32_t * n_layer_window, uint32_t * n_gpu_layers);
 
     LLAMA_API int llm_load_tensors(

--- a/include/llama.h
+++ b/include/llama.h
@@ -448,6 +448,12 @@ extern "C" {
               struct llama_model_params   params);
 
     LLAMA_API void llama_free_model(struct llama_model * model);
+    
+    enum NodeType{
+        NODE_TYPE_WORKER,
+        NODE_TYPE_FOWARDER,
+        NODE_TYPE_EXIT,
+    };
 
     LLAMA_API void llama_init_sockets      (struct llama_context * ctx, uint32_t n_world, uint32_t my_rank);
     LLAMA_API void llama_free_sockets      (struct llama_context * ctx, char ** msg);
@@ -455,7 +461,12 @@ extern "C" {
     LLAMA_API int  llama_send_device_info  (struct llama_context * ctx, struct device_info * dev_info);
     LLAMA_API int  llama_bcast_startup_args(struct llama_context * ctx, uint32_t rank, struct startup_args * args);
     LLAMA_API int  llama_bcast_layer_setup (struct llama_context * ctx, uint32_t * n_layer_window, uint32_t * n_gpu_layers);
-    LLAMA_API int  llama_rebuild_topo      (struct llama_context * ctx, uint32_t * n_layer_window, struct device_info * dev_info_set);
+    LLAMA_API int  llama_rebuild_topo      (struct llama_context * ctx, 
+                                                        uint32_t * n_layer_window, 
+                                              struct device_info * dev_info_set, 
+                                                         NodeType* node_type,
+                                                         char    * is_fowarder);
+    LLAMA_API int  llama_foward_messages   (struct llama_context * ctx);
     LLAMA_API int  llama_recv_layer_setup  (struct llama_context * ctx, uint32_t * n_layer_window, uint32_t * n_gpu_layers);
 
     LLAMA_API int llm_load_tensors(

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -20776,9 +20776,13 @@ int llama_rebuild_topo(llama_context * ctx,
 int llama_forward_messages(llama_context *ctx) {
     zmq::message_t message;
     int more = true;
-    
+    int timeout_ms = 10;
+    ctx->recv_socket->setsockopt(ZMQ_RCVTIMEO, &timeout_ms, sizeof(timeout_ms));
     while (more) {
-        ctx->recv_socket->recv(message, zmq::recv_flags::none);
+        auto recv_result = ctx->recv_socket->recv(message, zmq::recv_flags::none);
+        if (!recv_result) {
+            return -1;
+        }
         size_t more_size = sizeof(more);
         ctx->recv_socket->getsockopt(ZMQ_RCVMORE, &more, &more_size);
         

--- a/src/network-utils.cpp
+++ b/src/network-utils.cpp
@@ -1,0 +1,26 @@
+#include "network-utils.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+bool isPortOpen(const std::string& ip, uint32_t port, int timeout_sec) {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) return false;
+    
+    struct timeval tv;
+    tv.tv_sec = timeout_sec;
+    tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    
+    struct sockaddr_in server;
+    server.sin_addr.s_addr = inet_addr(ip.c_str());
+    server.sin_family = AF_INET;
+    server.sin_port = htons(port);
+    
+    int res = connect(sock, (struct sockaddr*)&server, sizeof(server));
+    close(sock);
+    return res == 0;
+}

--- a/src/network-utils.h
+++ b/src/network-utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+typedef unsigned int uint32_t;
+
+bool isPortOpen(const std::string& ip, uint32_t port, int timeout_sec = 2);


### PR DESCRIPTION
- During topology reconstruction: nodes assigned to the model layer (called workers) will sequentially attempt connections starting from the next worker. If unable to directly connect to the next worker, intermediate nodes capable of message forwarding (called forwarders) will be retained.

- After topology reconstruction: both workers and forwarders are reassigned ranks (following the original topology order), with `worker_rank` and `n_worker` variables preserved in workers to identify their ranks.

- Upon completion of inference, all nodes can exit normally.